### PR TITLE
feat: add reusable Button component with primary/secondary variants

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,12 +1,59 @@
-import './App.css'
+import { useState } from 'react';
+import Home from './pages/Home';
+import Contact from './pages/Contact';
+import Button from './components/ui/Button';
+import type { PageName } from './types';
+import './App.css';
 
 function App() {
+  const [currentPage, setCurrentPage] = useState<PageName>('home');
+
+  const switchToHome = (): void => setCurrentPage('home');
+  const switchToContact = (): void => setCurrentPage('contact');
 
   return (
     <>
-    <p>App Component</p>
+      {/* Navigation Header */}
+      <nav className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div className="flex items-center">
+              <h1 className="text-xl font-bold text-gray-900">Button Component Test</h1>
+            </div>
+            <div className="flex space-x-4">
+              <Button
+                text="Home"
+                variant={currentPage === 'home' ? 'primary' : 'secondary'}
+                size="sm"
+                onClick={switchToHome}
+              />
+              <Button
+                text="Contact"
+                variant={currentPage === 'contact' ? 'primary' : 'secondary'}
+                size="sm"
+                onClick={switchToContact}
+              />
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      {/* Page Content */}
+      <main>
+        {currentPage === 'home' && <Home />}
+        {currentPage === 'contact' && <Contact />}
+      </main>
+
+      {/* Footer */}
+      <footer className="bg-gray-800 text-white py-4">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <p className="text-sm">
+            Button Component Testing • Current Page: {currentPage === 'home' ? 'Home' : 'Contact'}
+          </p>
+        </div>
+      </footer>
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/client/src/components/ui/Button.tsx
+++ b/client/src/components/ui/Button.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import type { ButtonProps, ButtonVariant, ButtonSize } from '../../types';
+
+const Button: React.FC<ButtonProps> = ({
+  text,
+  onClick,
+  variant = 'primary',
+  size = 'md',
+  className = '',
+  disabled = false,
+  type = 'button'
+}) => {
+  // Base button styles
+  const baseStyles = 'font-medium rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed';
+  
+  // Variant styles
+  const variantStyles: Record<ButtonVariant, string> = {
+    primary: 'bg-[#009488] text-white hover:bg-[#0C827A] focus:ring-[#009488]',
+    secondary: 'bg-transparent border-2 border-[#009488] text-[#009488] hover:bg-[#009488] hover:text-white focus:ring-[#009488]'
+  };
+  
+  // Size styles
+  const sizeStyles: Record<ButtonSize, string> = {
+    sm: 'px-2 py-1 text-sm', // 8x16px equivalent
+    md: 'px-3 py-1.5 text-base', // 12x20px equivalent  
+    lg: 'px-4 py-2 text-lg' // 16x24px equivalent
+  };
+  
+  // Combine all styles
+  const buttonClasses = `${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]} ${className}`;
+  
+  return (
+    <button
+      type={type}
+      className={buttonClasses}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {text}
+    </button>
+  );
+};
+
+export default Button;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import './index.css'
+import './styles/index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(

--- a/client/src/pages/Contact.tsx
+++ b/client/src/pages/Contact.tsx
@@ -1,0 +1,151 @@
+import React, { useState } from 'react';
+import Button from '../components/ui/Button';
+import type { FormData } from '../types/index';
+
+const Contact: React.FC = () => {
+  const [formData, setFormData] = useState<FormData>({
+    name: '',
+    email: '',
+    message: ''
+  });
+
+  const handleSubmit = () => {
+    console.log('Form submitted:', formData);
+    alert(`Form submitted!\nName: ${formData.name}\nEmail: ${formData.email}\nMessage: ${formData.message}`);
+  };
+
+  const handleReset = () => {
+    setFormData({ name: '', email: '', message: '' });
+    console.log('Form reset');
+    alert('Form has been reset!');
+  };
+
+  const handleCancel = () => {
+    console.log('Form cancelled');
+    alert('Form cancelled!');
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
+  const isFormValid = formData.name.trim() && formData.email.trim() && formData.message.trim();
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-lg mx-auto">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-4">Contact Us</h1>
+          <p className="text-gray-600">Testing the Button component in a contact form context.</p>
+        </div>
+
+        <div className="bg-white shadow rounded-lg p-6">
+          <form className="space-y-6" onSubmit={(e) => e.preventDefault()}>
+            <div>
+              <label htmlFor="name" className="block text-sm font-medium text-gray-700">
+                Name
+              </label>
+              <input
+                type="text"
+                id="name"
+                name="name"
+                value={formData.name}
+                onChange={handleInputChange}
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-[#009488] focus:border-[#009488]"
+                placeholder="Your name"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                Email
+              </label>
+              <input
+                type="email"
+                id="email"
+                name="email"
+                value={formData.email}
+                onChange={handleInputChange}
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-[#009488] focus:border-[#009488]"
+                placeholder="your.email@example.com"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="message" className="block text-sm font-medium text-gray-700">
+                Message
+              </label>
+              <textarea
+                id="message"
+                name="message"
+                rows={4}
+                value={formData.message}
+                onChange={handleInputChange}
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-[#009488] focus:border-[#009488]"
+                placeholder="Your message here..."
+              />
+            </div>
+
+            {/* Button Testing Area */}
+            <div className="space-y-4">
+              <h3 className="text-lg font-medium text-gray-800">Form Actions</h3>
+              
+              {/* Primary Actions */}
+              <div className="flex flex-col sm:flex-row gap-3">
+                <Button
+                  text="Submit Form"
+                  variant="primary"
+                  size="md"
+                  onClick={handleSubmit}
+                  disabled={!isFormValid}
+                  type="submit"
+                  className="flex-1"
+                />
+                <Button
+                  text="Reset Form"
+                  variant="secondary"
+                  size="md"
+                  onClick={handleReset}
+                  type="reset"
+                  className="flex-1"
+                />
+              </div>
+
+              {/* Additional Button Tests */}
+              <div className="pt-4 border-t border-gray-200">
+                <h4 className="text-sm font-medium text-gray-600 mb-3">Additional Button Tests</h4>
+                <div className="grid grid-cols-2 gap-2">
+                  <Button
+                    text="Cancel"
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleCancel}
+                  />
+                  <Button
+                    text="Small Primary"
+                    variant="primary"
+                    size="sm"
+                    onClick={() => alert('Small primary clicked!')}
+                  />
+                  <Button
+                    text="Large Secondary"
+                    variant="secondary"
+                    size="lg"
+                    onClick={() => alert('Large secondary clicked!')}
+                    className="col-span-2"
+                  />
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Contact;

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import Button from '../components/ui/Button';
+
+const Home: React.FC = () => {
+  const handlePrimaryClick = () => {
+    console.log('Primary button clicked in Home!');
+    alert('Primary button clicked in Home!');
+  };
+
+  const handleSecondaryClick = () => {
+    console.log('Secondary button clicked in Home!');
+    alert('Secondary button clicked in Home!');
+  };
+
+  const handleSizeTestClick = () => {
+    console.log('Size test button clicked!');
+    alert('Size test button clicked!');
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md mx-auto">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-gray-900 mb-8">Home Page</h1>
+          <p className="text-gray-600 mb-8">Testing the reusable Button component with different variants and sizes.</p>
+        </div>
+
+        <div className="space-y-6">
+          {/* Primary Variants */}
+          <div className="space-y-4">
+            <h2 className="text-xl font-semibold text-gray-800">Primary Buttons</h2>
+            <div className="flex flex-col space-y-3">
+              <Button
+                text="Small Primary Button"
+                variant="primary"
+                size="sm"
+                onClick={handleSizeTestClick}
+              />
+              <Button
+                text="Medium Primary Button"
+                variant="primary"
+                size="md"
+                onClick={handlePrimaryClick}
+              />
+              <Button
+                text="Large Primary Button"
+                variant="primary"
+                size="lg"
+                onClick={handleSizeTestClick}
+              />
+            </div>
+          </div>
+
+          {/* Secondary Variants */}
+          <div className="space-y-4">
+            <h2 className="text-xl font-semibold text-gray-800">Secondary Buttons</h2>
+            <div className="flex flex-col space-y-3">
+              <Button
+                text="Small Secondary Button"
+                variant="secondary"
+                size="sm"
+                onClick={handleSizeTestClick}
+              />
+              <Button
+                text="Medium Secondary Button"
+                variant="secondary"
+                size="md"
+                onClick={handleSecondaryClick}
+              />
+              <Button
+                text="Large Secondary Button"
+                variant="secondary"
+                size="lg"
+                onClick={handleSizeTestClick}
+              />
+            </div>
+          </div>
+
+          {/* Disabled States */}
+          <div className="space-y-4">
+            <h2 className="text-xl font-semibold text-gray-800">Disabled States</h2>
+            <div className="flex flex-col space-y-3">
+              <Button
+                text="Disabled Primary"
+                variant="primary"
+                disabled={true}
+                onClick={handlePrimaryClick}
+              />
+              <Button
+                text="Disabled Secondary"
+                variant="secondary"
+                disabled={true}
+                onClick={handleSecondaryClick}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Home;

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -1,1 +1,9 @@
 @import "tailwindcss";
+
+/* Import Inter font for consistency with design specs */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* Ensure Inter is the default font family */
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,0 +1,22 @@
+// Page navigation types
+export type PageName = 'home' | 'contact';
+
+// Button component types
+export type ButtonVariant = 'primary' | 'secondary';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+export type ButtonProps = {
+  text: string;
+  onClick?: () => void;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  className?: string;
+  disabled?: boolean;
+  type?: 'button' | 'submit' | 'reset';
+};
+
+export type FormData = {
+  name: string;
+  email: string;
+  message: string;
+};

--- a/client/src/utils/classNames.ts
+++ b/client/src/utils/classNames.ts
@@ -1,0 +1,38 @@
+/**
+ * Utility function to combine CSS classes
+ * Filters out falsy values and joins remaining classes with spaces
+ * 
+ * @param classes - Array of class names (can include falsy values)
+ * @returns Combined class string
+ */
+export function classNames(...classes: (string | undefined | null | boolean)[]): string {
+  return classes.filter(Boolean).join(' ');
+}
+
+/**
+ * Alternative syntax that's more explicit about conditional classes
+ * 
+ * @param baseClasses - Base classes that are always applied
+ * @param conditionalClasses - Object with condition -> className pairs
+ * @returns Combined class string
+ */
+export function cn(
+  baseClasses: string,
+  conditionalClasses?: Record<string, boolean | undefined>
+): string {
+  let result = baseClasses;
+  
+  if (conditionalClasses) {
+    Object.entries(conditionalClasses).forEach(([className, condition]) => {
+      if (condition) {
+        result += ` ${className}`;
+      }
+    });
+  }
+  
+  return result;
+}
+
+// Example usage:
+// classNames('btn', isActive && 'btn-active', 'text-white')
+// cn('btn text-white', { 'btn-active': isActive, 'btn-disabled': disabled })


### PR DESCRIPTION
- Implement Button component with TypeScript support
- Add primary (#009488) and secondary variants with hover states
- Support sm/md/lg sizes and disabled states
- Create Home and Contact pages for testing
- Add centralized type definitions using `type` declarations
- Include navigation between test pages