### PR TITLE
feat: add style prop support and centralize Hero interface

### DIFF
--- a/client/src/components/ui/Heading.tsx
+++ b/client/src/components/ui/Heading.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { HeadingProps } from '../../types';
 import { getHeadingClasses, getHeadingStyles } from '../../utils/classNames';
 
@@ -7,6 +6,7 @@ const Heading: React.FC<HeadingProps> = ({
   level = 1,
   className = '',
   color = '#1E293B',
+  style = {},
   'aria-label': ariaLabel,
   id,
   'data-testid': testId,
@@ -16,14 +16,18 @@ const Heading: React.FC<HeadingProps> = ({
   const currentLevelStyles = getHeadingStyles(level);
   const headingClasses = getHeadingClasses(level, className);
   
+  // Combine default styles with custom styles
+  const combinedStyles: React.CSSProperties = {
+    color,
+    fontWeight: currentLevelStyles.weight,
+    lineHeight: currentLevelStyles.lineHeight,
+    ...style // Custom styles override defaults
+  };
+  
   // Common props to apply to any heading element
   const elementProps = {
     className: headingClasses,
-    style: { 
-      color,
-      fontWeight: currentLevelStyles.weight,
-      lineHeight: currentLevelStyles.lineHeight 
-    },
+    style: combinedStyles,
     'aria-label': ariaLabel,
     id,
     'data-testid': testId,
@@ -45,7 +49,7 @@ const Heading: React.FC<HeadingProps> = ({
     case 6:
       return <h6 {...elementProps}>{text}</h6>;
     default:
-      // Fallback to h1 for invalid levels, but this shouldn't happen with proper TypeScript typing
+      // Fallback to h1 for invalid levels
       return <h1 {...elementProps}>{text}</h1>;
   }
 };

--- a/client/src/components/ui/Paragraph.tsx
+++ b/client/src/components/ui/Paragraph.tsx
@@ -1,22 +1,10 @@
-import React from 'react';
-import type { ParagraphProps, ParagraphElement } from '../../types';
+import type { ParagraphProps } from '../../types';
 
-/**
- * Reusable Paragraph component for standardized body text
- * 
- * Features:
- * - Flexible element rendering (p, span, div)
- * - Custom styling support via className
- * - Accessibility best practices
- * - TypeScript support
- * 
- * @param props - ParagraphProps
- * @returns JSX.Element
- */
 const Paragraph: React.FC<ParagraphProps> = ({
   text,
   className = '',
   as = 'p',
+  style = {},
   'aria-label': ariaLabel,
   id,
   'data-testid': testId,
@@ -33,6 +21,7 @@ const Paragraph: React.FC<ParagraphProps> = ({
   // Common props to apply to any element
   const elementProps = {
     className: combinedClasses,
+    style, // Apply custom styles
     'aria-label': ariaLabel,
     id,
     'data-testid': testId,

--- a/client/src/sections/Hero.tsx
+++ b/client/src/sections/Hero.tsx
@@ -3,36 +3,13 @@ import Heading from "../components/ui/Heading";
 import Paragraph from "../components/ui/Paragraph";
 import Button from "../components/ui/Button";
 import heroimage from "../assets/images/hero/hero-image.webp";
-
-export interface HeroSectionProps {
-  /** Main heading text */
-  heading: string;
-  /** Subtitle/description text */
-  subtitle: string;
-  /** Primary call-to-action button */
-  primaryButton: {
-    text: string;
-    onClick: () => void;
-  };
-  /** Optional secondary button */
-  secondaryButton?: {
-    text: string;
-    onClick: () => void;
-  };
-  /** Background image from /assets */
-  backgroundImage?: string;
-  /** Additional CSS classes */
-  className?: string;
-  /** Test identifier */
-  "data-testid"?: string;
-}
+import type { HeroSectionProps } from "../types";
 
 const Hero: React.FC<HeroSectionProps> = ({
   heading,
   subtitle,
   primaryButton,
   secondaryButton,
-  backgroundImage,
   className = "",
   "data-testid": testId,
 }) => {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -32,6 +32,8 @@ export interface ParagraphProps {
   className?: string;
   /** HTML element to render as (defaults to 'p') */
   as?: ParagraphElement;
+  /** Inline styles object */
+  style?: React.CSSProperties;
   /** Accessibility label for screen readers */
   'aria-label'?: string;
   /** Unique identifier for the paragraph */
@@ -52,6 +54,8 @@ export interface HeadingProps {
   className?: string;
   /** Text color (defaults to design system primary text color) */
   color?: string;
+  /** Inline styles object */
+  style?: React.CSSProperties;
   /** Accessibility label for screen readers */
   'aria-label'?: string;
   /** Unique identifier for the heading */
@@ -100,7 +104,7 @@ export interface CardProps {
   'data-testid'?: string;
 }
 
-// Product types (extracted from Features.tsx)
+// Product types
 export interface Product {
   /** Unique identifier for the product */
   id: string;
@@ -118,7 +122,7 @@ export interface Product {
   defaultColor: string;
 }
 
-// Feature types (extracted from Features.tsx)
+// Feature types
 export interface Feature {
   /** Unique identifier for the feature */
   id: string;
@@ -134,7 +138,7 @@ export interface Feature {
 export type ProductActionHandler = (productName: string) => void;
 export type ColorSelectHandler = (productId: string, color: string) => void;
 
-// Features component types (extracted from Features.tsx)
+// Features component types
 export interface FeaturesProps {
   /** Section title */
   title?: string;
@@ -196,4 +200,28 @@ export interface FooterSection {
     href?: string;
     action?: string;
   }>;
+}
+
+// Hero section component types
+export interface HeroSectionProps {
+  /** Main heading text */
+  heading: string;
+  /** Subtitle/description text */
+  subtitle: string;
+  /** Primary call-to-action button */
+  primaryButton: {
+    text: string;
+    onClick: () => void;
+  };
+  /** Optional secondary button */
+  secondaryButton?: {
+    text: string;
+    onClick: () => void;
+  };
+  /** Background image from /assets */
+  backgroundImage?: string;
+  /** Additional CSS classes */
+  className?: string;
+  /** Test identifier */
+  "data-testid"?: string;
 }


### PR DESCRIPTION
- Add React.CSSProperties style prop to Heading and Paragraph components
- Move HeroSectionProps interface to centralized types file for consistency
- Fixes TypeScript errors when using textShadow in Hero component